### PR TITLE
Creditcoin shell scripts:  startup, configuration and node sanity

### DIFF
--- a/Server/check_node_sanity.sh
+++ b/Server/check_node_sanity.sh
@@ -1,0 +1,1 @@
+scripts/check_node_sanity.sh

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -52,12 +52,14 @@ function log_number_of_open_descriptors {
 
 # log public IP address daily to confirm it's static
 function log_public_ip_address {
-  [ `date +%H` == "00" ]  &&  [ `date +%M` == "00" ]  &&  {
+  # crontab job is scheduled to run twice an hour; use first one
+  (( $(date +%H) == 3 ))  &&  (( $(date +%M) < 30 ))  &&  {
     local public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
-    [ -n $public_ipv4_address ]  &&  {
-      echo Public IP address: $public_ipv4_address
+    timestamp
+    [ -n "$public_ipv4_address" ]  &&  {
+      echo " Public IP address is $public_ipv4_address"
     } || {
-      echo Unable to query public IP address.
+      echo " Unable to query public IP address."
       return 1
     }
   }

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -53,7 +53,7 @@ function log_number_of_open_descriptors {
 # log public IP address daily to confirm it's static
 function log_public_ip_address {
   # crontab job is scheduled to run twice an hour; use first one
-  (( $(date +%H) == 3 ))  &&  (( $(date +%M) < 30 ))  &&  {
+  (( 10#$(date +%H) == 3 ))  &&  (( $(date +%M) < 30 ))  &&  {
     local public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
     timestamp
     [ -n "$public_ipv4_address" ]  &&  {
@@ -95,8 +95,7 @@ function probe_endpoints_of_validator_peers {
 }
 
 
-max_peers=`ps -ef | grep -oP '(?<=maximum-peer-connectivity )[0-9]+' | head -1`
-[ -z $max_peers ]  &&  {
+ps -ef | grep -q "[u]sr/bin/sawtooth-validator"  ||  {
   timestamp
   echo " Validator is not running"
   exit 1

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -111,24 +111,24 @@ probe_endpoints_of_validator_peers open_peers  ||  exit 1
 
 log_number_of_open_descriptors || exit 1
 
-if (($open_peers < 2))
-then
-  tty -s  &&  {
+tty -s  &&  {
+  if (($open_peers < 2))
+  then
     read -p "Number of open Validator peers is $open_peers.  Restart Creditcoin node? (y/n) " yn
     case $yn in
     [Yy]*) $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
            ;;
     *) ;;
     esac
-  } || {
-    # crontab job
-    if (($open_peers == 0))
-    then
-      $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
-    else
-      check_if_stagnant_state  ||  $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
-    fi
-  }
-fi
+  fi
+} || {
+  # crontab job
+  if (($open_peers == 0))
+  then
+    $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
+  else
+    check_if_stagnant_state  ||  $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
+  fi
+}
 
 exit 0

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -78,7 +78,7 @@ function probe_endpoints_of_validator_peers {
     local port=`echo $p | cut -d: -f2`
     local preamble=" Peer $ipv4_address:$port is"
 
-    if nc -4 -z -w 1 $ipv4_address $port
+    if nc -4 -z -w 2 $ipv4_address $port
     then
       timestamp
       echo "$preamble open"

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+[ -x "$(command -v nc)" ]  ||  {
+  echo 'netcat' not found.
+  exit 1
+}
+
+
+timestamp() {
+  local ts=`date +"%Y-%m-%d %H:%M:%S"`
+  echo -n $ts
+}
+
+
+function get_block_tip {
+  curl http://$REST_API_ENDPOINT/blocks 2>/dev/null | grep -o '"block_num": "[^"]*' | head -1 | cut -d'"' -f4
+}
+
+
+function check_if_stagnant_state {
+  local block_tip=$(get_block_tip)
+  [ -z $block_tip ]  &&  return 1
+
+  previous_block_tip=`cat $CREDITCOIN_HOME/.last_block_tip.txt 2>/dev/null`  &&  {
+    [ $block_tip = $previous_block_tip ]  &&  {
+      rm $CREDITCOIN_HOME/.last_block_tip.txt
+      return 1    # Validator is stagnant since block tip hasn't changed since last run
+    }
+  }
+
+  echo $block_tip > $CREDITCOIN_HOME/.last_block_tip.txt
+
+  return 0
+}
+
+
+function restart_creditcoin_node {
+  cd $CREDITCOIN_HOME  ||  return 1
+  docker_compose=`ls -t *.yaml | head -1`
+  [ -z $docker_compose ]  &&  return 1
+
+  [ -x "$(command -v docker-compose)" ]  ||  {
+    echo 'docker-compose' not found.
+    return 1
+  }
+
+  timestamp
+  echo " Resetting Creditcoin node"
+  sudo docker-compose -f $docker_compose down 2>/dev/null
+  sudo docker-compose -f $docker_compose up -d  &&  {
+    timestamp
+    echo " Restarted Creditcoin node"
+  }
+
+  return 0
+}
+
+
+max_peers=`ps -ef | grep -oP '(?<=maximum-peer-connectivity )[0-9]+' | head -1`
+[ -z $max_peers ]  &&  {
+  timestamp
+  echo " Validator is not running"
+  exit 1
+}
+
+[ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
+[ -z $REST_API_ENDPOINT ]  &&  REST_API_ENDPOINT=localhost:8008
+
+peers=`curl http://$REST_API_ENDPOINT/peers 2>/dev/null | grep tcp:// | cut -d \" -f2 | sed 's/^.*\///'`
+
+
+# For dynamic peering, need to log 'netcat' probe results to view history of connected peers over time.
+
+open_peers=0
+for p in $peers; do
+  ipv4_address=`echo $p | cut -d: -f1`
+  port=`echo $p | cut -d: -f2`
+  preamble=" Peer $ipv4_address:$port is"
+
+  if nc -4 -z -w 1 $ipv4_address $port
+  then
+    timestamp
+    echo "$preamble open"
+    open_peers=$((open_peers + 1))
+  else
+    timestamp
+    echo "$preamble closed"
+  fi
+done
+
+
+# find open descriptors for all Validator processes
+
+validator_pids=`ps -ef | grep "[u]sr/bin/sawtooth-validator" | awk '{print $2}'`
+for v in $validator_pids; do
+  open_this_vpid=`sudo vpid=$v sh -c 'lsof -p $vpid | wc -l'`
+  open_descriptors=$((open_descriptors + open_this_vpid))
+done
+timestamp
+echo " Open file descriptors: $open_descriptors"
+
+
+if (($open_peers < 2))
+then
+  if (($open_peers == 0))
+  then
+    restart_creditcoin_node  ||  exit 1
+  else
+    tty -s  &&  {
+      restart_creditcoin_node  ||  exit 1
+    } || {
+      # crontab job
+      check_if_stagnant_state  ||  restart_creditcoin_node  ||  exit 1
+    }
+  fi
+fi
+
+exit 0

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 [ -x "$(command -v nc)" ]  ||  {
   echo 'netcat' not found.
   exit 1
@@ -14,6 +15,7 @@ function timestamp {
 
 function get_block_tip {
   curl http://$REST_API_ENDPOINT/blocks 2>/dev/null | grep -o '"block_num": "[^"]*' | head -1 | cut -d'"' -f4
+  return $?
 }
 
 
@@ -21,9 +23,9 @@ function check_if_stagnant_state {
   local block_tip=$(get_block_tip)
   [ -z $block_tip ]  &&  return 1
 
-  previous_block_tip=`cat $CREDITCOIN_HOME/.last_block_tip 2>/dev/null`  &&  {
+  local previous_block_tip=`cat $CREDITCOIN_HOME/.last_block_tip 2>/dev/null`  &&  {
     [ $block_tip = $previous_block_tip ]  &&  {
-      rm $CREDITCOIN_HOME/.last_block_tip
+      rm $CREDITCOIN_HOME/.last_block_tip 2>/dev/null
       return 1    # Validator is stagnant since block tip hasn't changed since last run
     }
   }
@@ -34,23 +36,58 @@ function check_if_stagnant_state {
 }
 
 
-function restart_creditcoin_node {
-  cd $CREDITCOIN_HOME  ||  return 1
-  docker_compose=`ls -t *.yaml | head -1`
-  [ -z $docker_compose ]  &&  return 1
-
-  [ -x "$(command -v docker-compose)" ]  ||  {
-    echo 'docker-compose' not found.
-    return 1
-  }
-
+# find open descriptors for all Validator processes
+function log_number_of_open_descriptors {
+  local validator_pids=`ps -ef | grep "[u]sr/bin/sawtooth-validator" | awk '{print $2}'`
+  for v in $validator_pids; do
+    open_this_vpid=`sudo vpid=$v sh -c 'lsof -p $vpid | wc -l'`
+    open_descriptors=$((open_descriptors + open_this_vpid))
+  done
   timestamp
-  echo " Resetting Creditcoin node"
-  sudo docker-compose -f $docker_compose down 2>/dev/null
-  sudo docker-compose -f $docker_compose up -d  &&  {
-    timestamp
-    echo " Restarted Creditcoin node"
+  echo " Open file descriptors: $open_descriptors"
+
+  return 0
+}
+
+
+# log public IP address daily to confirm it's static
+function log_public_ip_address {
+  [ `date +%H` == "00" ]  &&  [ `date +%M` == "00" ]  &&  {
+    local public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
+    [ -n $public_ipv4_address ]  &&  {
+      echo Public IP address: $public_ipv4_address
+    } || {
+      echo Unable to query public IP address.
+      return 1
+    }
   }
+  return 0
+}
+
+
+# For dynamic peering, need to log 'netcat' probe results to view history of connected peers over time.
+function probe_endpoints_of_validator_peers {
+  local peers=`curl http://$REST_API_ENDPOINT/peers 2>/dev/null | grep tcp:// | cut -d \" -f2 | sed 's/^.*\///'`
+  local -n return_open_peers=$1
+  local open=0
+
+  for p in $peers; do
+    local ipv4_address=`echo $p | cut -d: -f1`
+    local port=`echo $p | cut -d: -f2`
+    local preamble=" Peer $ipv4_address:$port is"
+
+    if nc -4 -z -w 1 $ipv4_address $port
+    then
+      timestamp
+      echo "$preamble open"
+      open=$((open + 1))
+    else
+      timestamp
+      echo "$preamble closed"
+    fi
+  done
+
+  return_open_peers=$open
 
   return 0
 }
@@ -63,56 +100,34 @@ max_peers=`ps -ef | grep -oP '(?<=maximum-peer-connectivity )[0-9]+' | head -1`
   exit 1
 }
 
+log_public_ip_address
+
 [ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
 [ -z $REST_API_ENDPOINT ]  &&  REST_API_ENDPOINT=localhost:8008
 
-peers=`curl http://$REST_API_ENDPOINT/peers 2>/dev/null | grep tcp:// | cut -d \" -f2 | sed 's/^.*\///'`
-
-
-# For dynamic peering, need to log 'netcat' probe results to view history of connected peers over time.
-
 open_peers=0
-for p in $peers; do
-  ipv4_address=`echo $p | cut -d: -f1`
-  port=`echo $p | cut -d: -f2`
-  preamble=" Peer $ipv4_address:$port is"
+probe_endpoints_of_validator_peers open_peers  ||  exit 1
 
-  if nc -4 -z -w 1 $ipv4_address $port
-  then
-    timestamp
-    echo "$preamble open"
-    open_peers=$((open_peers + 1))
-  else
-    timestamp
-    echo "$preamble closed"
-  fi
-done
-
-
-# find open descriptors for all Validator processes
-
-validator_pids=`ps -ef | grep "[u]sr/bin/sawtooth-validator" | awk '{print $2}'`
-for v in $validator_pids; do
-  open_this_vpid=`sudo vpid=$v sh -c 'lsof -p $vpid | wc -l'`
-  open_descriptors=$((open_descriptors + open_this_vpid))
-done
-timestamp
-echo " Open file descriptors: $open_descriptors"
-
+log_number_of_open_descriptors || exit 1
 
 if (($open_peers < 2))
 then
-  if (($open_peers == 0))
-  then
-    restart_creditcoin_node  ||  exit 1
-  else
-    tty -s  &&  {
-      restart_creditcoin_node  ||  exit 1
-    } || {
-      # crontab job
-      check_if_stagnant_state  ||  restart_creditcoin_node  ||  exit 1
-    }
-  fi
+  tty -s  &&  {
+    read -p "Number of open Validator peers is $open_peers.  Restart Creditcoin node? (y/n) " yn
+    case $yn in
+    [Yy]*) $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
+           ;;
+    *) ;;
+    esac
+  } || {
+    # crontab job
+    if (($open_peers == 0))
+    then
+      $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
+    else
+      check_if_stagnant_state  ||  $CREDITCOIN_HOME/start_creditcoin.sh  ||  exit 1
+    fi
+  }
 fi
 
 exit 0

--- a/Server/scripts/check_node_sanity.sh
+++ b/Server/scripts/check_node_sanity.sh
@@ -6,7 +6,7 @@
 }
 
 
-timestamp() {
+function timestamp {
   local ts=`date +"%Y-%m-%d %H:%M:%S"`
   echo -n $ts
 }
@@ -21,14 +21,14 @@ function check_if_stagnant_state {
   local block_tip=$(get_block_tip)
   [ -z $block_tip ]  &&  return 1
 
-  previous_block_tip=`cat $CREDITCOIN_HOME/.last_block_tip.txt 2>/dev/null`  &&  {
+  previous_block_tip=`cat $CREDITCOIN_HOME/.last_block_tip 2>/dev/null`  &&  {
     [ $block_tip = $previous_block_tip ]  &&  {
-      rm $CREDITCOIN_HOME/.last_block_tip.txt
+      rm $CREDITCOIN_HOME/.last_block_tip
       return 1    # Validator is stagnant since block tip hasn't changed since last run
     }
   }
 
-  echo $block_tip > $CREDITCOIN_HOME/.last_block_tip.txt
+  echo $block_tip > $CREDITCOIN_HOME/.last_block_tip
 
   return 0
 }

--- a/Server/scripts/configure_creditcoin.sh
+++ b/Server/scripts/configure_creditcoin.sh
@@ -3,23 +3,92 @@
 [ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
 cd $CREDITCOIN_HOME  ||  exit 1
 
-# allow sudo execution in crontab without tty
-cc_user=`whoami`
-sudo grep -q "$cc_user ALL" /etc/sudoers  ||  {
-  echo "$cc_user ALL=(ALL) NOPASSWD:SETENV: /usr/bin/docker-compose, /bin/sh" | sudo EDITOR='tee -a' visudo >/dev/null
+
+function remove_job_that_runs_sanity_script {
+  crontab -l | grep -v CREDITCOIN_HOME | crontab -
+  return $?
 }
 
 
-# schedule job to periodically run sanity script
+function schedule_job_to_run_sanity_script {
+  # allow sudo execution in crontab without tty
+  cc_user=`whoami`
+  sudo grep -q "$cc_user ALL" /etc/sudoers  ||  {
+    echo "$cc_user ALL=(ALL) NOPASSWD:SETENV: /usr/bin/docker-compose, /bin/sh" | sudo EDITOR='tee -a' visudo >/dev/null
+  }
 
-crontab -l | grep -q CREDITCOIN_HOME  ||  {
-  echo CREDITCOIN_HOME is $CREDITCOIN_HOME
-  minutes_after_hour1=$((`date +%s` % 30))
-  minutes_after_hour2=$(($minutes_after_hour1 + 30))
 
-  (crontab -l 2>/dev/null;
-   echo CREDITCOIN_HOME=$CREDITCOIN_HOME;
-   echo "$minutes_after_hour1,$minutes_after_hour2 * * * * \$CREDITCOIN_HOME/check_node_sanity.sh >> \$CREDITCOIN_HOME/check_node_sanity.log 2>>\$CREDITCOIN_HOME/check_node_sanity-error.log") | crontab -
+  # schedule job to periodically run sanity script by appending to current schedule
+
+  crontab -l | grep -q CREDITCOIN_HOME  ||  {
+    echo CREDITCOIN_HOME is $CREDITCOIN_HOME
+    minutes_after_hour1=$((`date +%s` % 30))
+    minutes_after_hour2=$(($minutes_after_hour1 + 30))
+
+    (crontab -l 2>/dev/null;
+     echo CREDITCOIN_HOME=$CREDITCOIN_HOME;
+     echo "$minutes_after_hour1,$minutes_after_hour2 * * * * \$CREDITCOIN_HOME/check_node_sanity.sh >> \$CREDITCOIN_HOME/check_node_sanity.log 2>>\$CREDITCOIN_HOME/check_node_sanity-error.log") | crontab -
+  }
+
+  return 0
 }
+
+
+function validate_rpc_url {
+  local rpc_mainnet=$1
+  [ -z $rpc_mainnet ]  &&  return 1
+
+  fqdn_port=`echo $rpc_mainnet | awk -F/ '{print $3}'`
+  fqdn=`echo $fqdn_port | cut -d: -f1`
+  port=`echo $fqdn_port | awk -F: '{print $2}'`    # initially assume user specified UDP port number of an RPC proxy
+
+  udp="-u"
+  [ -z $port ]  &&  {
+    # no UDP port was specified; transport is HTTP/S, ie, TCP
+    udp=
+    transport=`echo $rpc_mainnet | cut -d: -f1`
+    [ $transport = https ]  &&  port=443  ||  {
+      [ $transport = http ]  &&  port=80
+    }
+  }
+
+  nc -z $udp -w 1 $fqdn $port
+  rc=$?
+  [ $rc = 1 ]  &&  echo "Warning: RPC port at $rpc_mainnet isn't open"
+
+  return $rc
+}
+
+
+function define_fields_in_gateway_config {
+  local GATEWAY_CONFIG=gatewayConfig.json
+  echo "Enter RPC mainnet nodes (eg. https://mainnet.infura.io/v3/...  or  http://localhost:8545)."
+  read -p "Bitcoin RPC: " bitcoin_rpc
+  validate_rpc_url $bitcoin_rpc  &&  {
+    sed -i "s~<bitcoin_rpc_node_url>~$bitcoin_rpc~g" $GATEWAY_CONFIG    # delimiter is ~ since RPC URL contains /
+  }  ||  return 1
+
+  read -p "Ethereum RPC: " ethereum_rpc
+  validate_rpc_url $ethereum_rpc  &&  {
+    sed -i "s~<ethereum_node_url>~$ethereum_rpc~g" $GATEWAY_CONFIG
+  }  ||  return 1
+
+  return 0
+}
+
+
+for i in "$@"
+do
+case $i in
+    -r*|--remove*)
+    remove_job_that_runs_sanity_script  &&  exit 0  ||  exit 1
+    ;;
+    *)
+    ;;
+esac
+done
+
+schedule_job_to_run_sanity_script  ||  exit 1
+define_fields_in_gateway_config  ||  exit 1
 
 exit 0

--- a/Server/scripts/configure_creditcoin.sh
+++ b/Server/scripts/configure_creditcoin.sh
@@ -102,14 +102,14 @@ function define_fields_in_gateway_config {
 
   # remove any existing RPC URLs
   cp -p $GATEWAY_CONFIG "$GATEWAY_CONFIG"_orig
-  sed -i '/"rpc"/d' $GATEWAY_CONFIG
+  sed -i.bak '/"rpc"/d' $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
 
   read -p "Bitcoin RPC: " bitcoin_rpc
   validate_rpc_url $bitcoin_rpc  &&  {
-    sed -i "s~<bitcoin_rpc_node_url>~$bitcoin_rpc~w btc_change.txt" $GATEWAY_CONFIG    # delimiter is ~ since RPC URL contains /
+    sed -i.bak "s~<bitcoin_rpc_node_url>~$bitcoin_rpc~w btc_change.txt" $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak    # delimiter is ~ since RPC URL contains /
     [ -s btc_change.txt ]  ||  {
       # original <bitcoin_..._url> not found; insert new value
-      sed -i 's~"bitcoin"[[:blank:]]*:[[:blank:]]*{~&\n        "rpc": "'$bitcoin_rpc'",~' $GATEWAY_CONFIG
+      sed -i.bak 's~"bitcoin"[[:blank:]]*:[[:blank:]]*{~&\'$'\n''        "rpc": "'$bitcoin_rpc'",~' $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
     }
     rm btc_change.txt 2>/dev/null
   }  ||  {
@@ -119,11 +119,11 @@ function define_fields_in_gateway_config {
 
   read -p "Ethereum RPC: " ethereum_rpc
   validate_rpc_url $ethereum_rpc  &&  {
-    sed -i "s~<ethereum_node_url>~$ethereum_rpc~w eth_change.txt" $GATEWAY_CONFIG
+    sed -i.bak "s~<ethereum_node_url>~$ethereum_rpc~w eth_change.txt" $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
     [ -s eth_change.txt ]  ||  {
-      sed -i 's~"ethereum"[[:blank:]]*:[[:blank:]]*{~&\n        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG
-      sed -i 's~"ethless"[[:blank:]]*:[[:blank:]]*{~&\n        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG
-      sed -i 's~"erc20"[[:blank:]]*:[[:blank:]]*{~&\n        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG
+      sed -i.bak 's~"ethereum"[[:blank:]]*:[[:blank:]]*{~&\'$'\n''        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
+      sed -i.bak 's~"ethless"[[:blank:]]*:[[:blank:]]*{~&\'$'\n''        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
+      sed -i.bak 's~"erc20"[[:blank:]]*:[[:blank:]]*{~&\'$'\n''        "rpc": "'$ethereum_rpc'",~' $GATEWAY_CONFIG  &&  rm ${GATEWAY_CONFIG}.bak
     }
     rm eth_change.txt 2>/dev/null
   }  ||  {

--- a/Server/scripts/configure_creditcoin.sh
+++ b/Server/scripts/configure_creditcoin.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+[ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
+cd $CREDITCOIN_HOME  ||  exit 1
+
+# allow sudo execution in crontab without tty
+cc_user=`whoami`
+sudo grep -q "$cc_user ALL" /etc/sudoers  ||  {
+  echo "$cc_user ALL=(ALL) NOPASSWD:SETENV: /usr/bin/docker-compose, /bin/sh" | sudo EDITOR='tee -a' visudo >/dev/null
+}
+
+
+# schedule job to periodically run sanity script
+
+crontab -l | grep -q CREDITCOIN_HOME  ||  {
+  echo CREDITCOIN_HOME is $CREDITCOIN_HOME
+  minutes_after_hour1=$((`date +%s` % 30))
+  minutes_after_hour2=$(($minutes_after_hour1 + 30))
+
+  (crontab -l 2>/dev/null;
+   echo CREDITCOIN_HOME=$CREDITCOIN_HOME;
+   echo "$minutes_after_hour1,$minutes_after_hour2 * * * * \$CREDITCOIN_HOME/check_node_sanity.sh >> \$CREDITCOIN_HOME/check_node_sanity.log 2>>\$CREDITCOIN_HOME/check_node_sanity-error.log") | crontab -
+}
+
+exit 0

--- a/Server/scripts/consensus.sh
+++ b/Server/scripts/consensus.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+os_name="$(uname -s)"
+case "${os_name}" in
+  Linux*)
+    NETCAT=nc
+    ;;
+  Darwin*)
+    NETCAT=ncat    # 'nc' isn't reliable on macOS
+    ;;
+  *) echo "Unsupported operating system: $os_name"
+     exit 1
+     ;;
+esac
+
+[ -z "$REST_API_ENDPOINT" ]  &&  REST_API_ENDPOINT=localhost:8008
+echo REST_API_ENDPOINT is $REST_API_ENDPOINT
+
+host=`echo $REST_API_ENDPOINT | cut -d: -f1`
+port=`echo $REST_API_ENDPOINT | awk -F: '{print $2}'`
+
+$NETCAT -z -w 2 $host $port  &&  {
+  consensus=`curl http://$REST_API_ENDPOINT/blocks | grep consensus | sed 's/^.*://' | cut -d \" -f2`
+  rc=$?
+  [ $rc = 0 ]  &&  {
+    for c in $consensus
+    do
+      decoded_data=`echo $c | base64 --decode`
+      decoded_epoch_time=`echo $decoded_data | awk -F: '{print $NF}'`
+      echo `date +"%Y-%m-%d %H:%M:%S" -d @$decoded_epoch_time` $decoded_data
+    done
+  }
+}  ||  {
+  echo "Endpoint $REST_API_ENDPOINT isn't open."
+  rc=1
+}
+
+exit $rc

--- a/Server/scripts/consensus.sh
+++ b/Server/scripts/consensus.sh
@@ -27,7 +27,7 @@ $NETCAT -z -w 2 $host $port  &&  {
     do
       decoded_data=`echo $c | base64 --decode`
       decoded_epoch_time=`echo $decoded_data | awk -F: '{print $NF}'`
-      echo `date +"%Y-%m-%d %H:%M:%S" -d @$decoded_epoch_time` $decoded_data
+      echo `date +"%Y-%m-%d %H:%M:%S" -d @$decoded_epoch_time` $decoded_data    # display timestamp in human-readable format
     done
   }
 }  ||  {

--- a/Server/scripts/install_apt_packages.sh
+++ b/Server/scripts/install_apt_packages.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+
+function import_repository_keys {
+  local rc=0
+  ubuntu_version=$(lsb_release -cs)
+  [ "$ubuntu_version" = "xenial" ]  &&  [ -n "$1" ]  &&  KEYS="$1"  &&  {
+    # make APT repository keys trusted
+    gpg2 --keyserver keyserver.ubuntu.com --recv-keys $KEYS 2>/dev/null
+    gpg2 --no-default-keyring -a --export $KEYS | gpg2 --no-default-keyring --keyring ~/.gnupg/trustedkeys.gpg --import - 2>/dev/null
+    rc=$?
+  }
+  return $rc
+}
+
+
+function install_packages {
+  local packages_list="$1"
+  for package in "$packages_list"
+  do
+    sudo apt-get install -y $package  &&
+    apt-get source $package      ||  return 1
+  done
+  return 0
+}
+
+
+os_name="$(uname -s)"
+case "${os_name}" in
+  Linux*)
+    ;;
+  *) echo "Unsupported operating system: $os_name"
+     exit 1
+     ;;
+esac
+
+
+PACKAGES_LIST="$1"
+[ -n "$PACKAGES_LIST" ]  ||  {
+  echo List of APT package names is required.
+  exit 1
+}
+
+KEYS_LIST="$2"
+[ -n "$KEYS_LIST" ]  &&  {
+  for key in $KEYS_LIST
+  do
+    (( 16#$key ))
+    [ $? = 0 ]  ||  {
+      echo Invalid hex key: $key
+      exit 1
+    }
+  done
+}
+
+rc=0
+
+sudo cp -p /etc/apt/sources.list /etc/apt/sources.list_bak
+sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list    # enable download of source archives which contain package signatures
+sudo apt-get update                  &&
+import_repository_keys "$KEYS_LIST"  &&
+install_packages "$PACKAGES_LIST"    ||  rc=1
+sudo mv /etc/apt/sources.list_bak /etc/apt/sources.list
+
+exit $rc

--- a/Server/scripts/sha256_speed_test.sh
+++ b/Server/scripts/sha256_speed_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+[ -x "$(command -v openssl)" ]  ||  {
+  echo 'OpenSSL' not found.
+  exit 1
+}
+
+
+function timestamp {
+  local ts=`date +"%Y-%m-%d %H:%M:%S"`
+  echo -n $ts
+}
+
+
+[ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
+cd $CREDITCOIN_HOME  ||  exit 1
+
+throughput=`openssl speed sha256 2>&1 | grep "64 size" | cut -d: -f2 |  awk '{print $1}'`
+[ -n "$throughput" ]  &&  {
+  timestamp
+  echo " $throughput"
+}  ||  exit 1
+
+exit 0

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+[ -x "$(command -v nc)" ]  ||  {
+  echo 'netcat' not found.
+  exit 1
+}
+
+[ -x "$(command -v openssl)" ]  ||  {
+  echo 'OpenSSL' not found.
+  exit 1
+}
+
+[ -x "$(command -v docker-compose)" ]  ||  {
+  echo 'docker-compose' not found.
+  exit 1
+}
+
+
+function define_fields_in_gateway_config {
+  GATEWAY_CONFIG=gatewayConfig.json
+  return 0
+}
+
+
+function restart_creditcoin_node {
+  docker_compose=`ls -t *.yaml | head -1`
+  [ -z $docker_compose ]  &&  return 1
+
+  public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
+  [ -z $public_ipv4_address ]  &&  {
+    echo Unable to query public IP address.
+    return 1
+  }
+
+  sed -i "s/\(endpoint tcp:\/\/\).*\(:\)/\1$public_ipv4_address\2/g" $docker_compose
+  validator_endpoint_port=`grep endpoint $docker_compose | cut -d: -f3 | awk '{print $1}'`
+
+  sudo docker-compose -f $docker_compose down 2>/dev/null
+  if sudo docker-compose -f $docker_compose up -d
+  then
+    echo Started Creditcoin node
+
+    # check if Validator endpoint is reachable from internet
+    nc -4 -z -w 1  $public_ipv4_address  $validator_endpoint_port  ||  {
+      echo -n "TCP port $validator_endpoint_port isn't open. "
+      validator=`ps -ef | grep "[u]sr/bin/sawtooth-validator"`
+      [[ -z $validator ]]  &&  echo "Validator isn't running."  ||  echo Check firewall rules.
+      return 1
+    }
+
+    rc=0
+  else
+    echo Failed to start Creditcoin node
+    rc=1
+  fi
+
+  return $rc
+}
+
+
+function run_sha256_speed_test {
+  echo Checking processing specification of this machine
+  BASELINE=7565854    # measured on Xeon Platinum 8171M CPU @ 2.60GHz
+  openssl speed sha256 2>sha256_speed.txt >/dev/null
+  throughput=`grep "64 size" sha256_speed.txt | cut -d: -f2 |  awk '{print $1}'`
+  rm sha256_speed.txt
+  if (( throughput < BASELINE ))
+  then
+    echo This machine lacks sufficient power to run Creditcoin software.
+    return 1
+  fi
+  return 0
+}
+
+
+run_sha256_speed_test  ||  exit 1
+
+[ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
+cd $CREDITCOIN_HOME  ||  exit 1
+echo CREDITCOIN_HOME is $CREDITCOIN_HOME
+
+define_fields_in_gateway_config  ||  exit 1
+
+restart_creditcoin_node  ||  exit 1
+
+exit 0

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -120,15 +120,18 @@ function get_docker_compose_file_name {
 
   docker_compose_reference=`ls -t *.yaml | head -1`
   [ -z "$docker_compose_reference" ]  &&  return 1
-  while :
-  do
-    read -p "Enter name of Docker compose file ($docker_compose_reference) " user_entered
-    [ -z "$user_entered" ]  &&  break
-    [ -s $CREDITCOIN_HOME/$user_entered ]  &&  {
-      docker_compose_reference=$user_entered
-      break
-    }  ||  echo $user_entered not found.
-  done
+
+  tty -s  &&  {
+    while :
+    do
+      read -p "Enter name of Docker compose file ($docker_compose_reference) " user_entered
+      [ -z "$user_entered" ]  &&  break
+      [ -s $CREDITCOIN_HOME/$user_entered ]  &&  {
+        docker_compose_reference=$user_entered
+        break
+      }  ||  echo $user_entered not found.
+    done
+  }
 
   eval $1=\$docker_compose_reference    # return by reference
   return 0
@@ -271,7 +274,7 @@ function check_sha256_throughput {
 
   (( median_throughput < BASELINE ))  &&  {
     echo Warning: this machine lacks sufficient power to run Creditcoin software.
-    return 1
+#    return 1
   }
   return 0
 }

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -75,7 +75,7 @@ function restart_creditcoin_node {
     return 1
   }
 
-  last_public_ipv4_address=`grep "Public IP" $CREDITCOIN_HOME/check_node_sanity.log | tail -1 | awk '{print $NF}'`
+  local last_public_ipv4_address=`grep "Public IP" $CREDITCOIN_HOME/check_node_sanity.log | tail -1 | awk '{print $NF}'`
   [ -n "$last_public_ipv4_address" ]  &&  [ $last_public_ipv4_address != $public_ipv4_address ]  &&  {
     # write warning to stderr
     >&2 echo "Warning: Public IP address has recently changed.  Creditcoin nodes cannot have dynamic IP addresses."

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -16,14 +16,8 @@
 }
 
 
-function define_fields_in_gateway_config {
-  GATEWAY_CONFIG=gatewayConfig.json
-  return 0
-}
-
-
 function restart_creditcoin_node {
-  docker_compose=`ls -t *.yaml | head -1`
+  local docker_compose=`ls -t *.yaml | head -1`
   [ -z $docker_compose ]  &&  return 1
 
   public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
@@ -78,8 +72,6 @@ run_sha256_speed_test  ||  exit 1
 [ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
 cd $CREDITCOIN_HOME  ||  exit 1
 echo CREDITCOIN_HOME is $CREDITCOIN_HOME
-
-define_fields_in_gateway_config  ||  exit 1
 
 restart_creditcoin_node  ||  exit 1
 

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -173,7 +173,7 @@ function restart_creditcoin_node {
   local docker_compose
   get_docker_compose_file_name  docker_compose  ||  return 1
 
-  local public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
+  local public_ipv4_address=`curl https://checkip.amazonaws.com 2>/dev/null`
   [ -z $public_ipv4_address ]  &&  {
     echo Unable to query public IP address.
     return 1

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -53,26 +53,27 @@ function restart_creditcoin_node {
 
 
 function run_sha256_speed_test {
-  echo Checking processing specification of this machine
-  BASELINE=7565854    # measured on Xeon Platinum 8171M CPU @ 2.60GHz
-  openssl speed sha256 2>sha256_speed.txt >/dev/null
-  throughput=`grep "64 size" sha256_speed.txt | cut -d: -f2 |  awk '{print $1}'`
-  rm sha256_speed.txt
-  if (( throughput < BASELINE ))
-  then
-    echo This machine lacks sufficient power to run Creditcoin software.
-    return 1
-  fi
+  local SHA256_SPEED=sha256_speed.txt
+  [ -f $SHA256_SPEED ]  ||  {
+    echo Checking processing specification of this machine
+    local BASELINE=7565854    # measured on Xeon Platinum 8171M CPU @ 2.60GHz
+    openssl speed sha256 2>$SHA256_SPEED >/dev/null
+    local throughput=`grep "64 size" $SHA256_SPEED | cut -d: -f2 |  awk '{print $1}'`
+    if (( throughput < BASELINE ))
+    then
+      echo This machine lacks sufficient power to run Creditcoin software.
+      return 1
+    fi
+  }
   return 0
 }
 
-
-run_sha256_speed_test  ||  exit 1
 
 [ -z $CREDITCOIN_HOME ]  &&  CREDITCOIN_HOME=~/Server
 cd $CREDITCOIN_HOME  ||  exit 1
 echo CREDITCOIN_HOME is $CREDITCOIN_HOME
 
+run_sha256_speed_test  ||  exit 1
 restart_creditcoin_node  ||  exit 1
 
 exit 0

--- a/Server/scripts/start_creditcoin.sh
+++ b/Server/scripts/start_creditcoin.sh
@@ -16,18 +16,66 @@
 }
 
 
+function evaluate_candidates_for_dynamic_peering {
+  [ -f $CREDITCOIN_HOME/check_node_sanity.log ]  ||  return 1
+
+  local -n seed=$1
+  local unique_open_peers_by_frequency=`grep open $CREDITCOIN_HOME/check_node_sanity.log | awk '{print $4}' | sort | uniq -c | sort -nr | awk '{print $2}' | tr '\r\n' ' '`
+  local s=0
+
+  # iterate over open peers from most to least frequent
+  for open_peer in $unique_open_peers_by_frequency; do
+    host=`echo $open_peer | cut -d: -f1`
+    port=`echo $open_peer | awk -F: '{print $2}'`
+
+    ((s == 1))  &&  {
+      # don't select both seeds from same subnet
+      read octet1 octet2 octet3 octet4 <<<"${host//./ }"
+      read s0_octet1 s0_octet2 s0_octet3 s0_octet4 <<<"${seed[0]//./ }"
+      [ $octet1 = $s0_octet1 ]  &&  [ $octet2 = $s0_octet2 ]  &&  continue
+    }
+
+    nc -z -w 1 $host $port  &&  {
+      seed[$s]=$open_peer
+      ((++s == 2))  &&  break
+    }
+  done
+
+  return 0
+}
+
+
 function restart_creditcoin_node {
   local docker_compose=`ls -t *.yaml | head -1`
   [ -z $docker_compose ]  &&  return 1
 
-  public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
+  local public_ipv4_address=`curl https://ifconfig.me 2>/dev/null`
   [ -z $public_ipv4_address ]  &&  {
     echo Unable to query public IP address.
     return 1
   }
 
-  sed -i "s/\(endpoint tcp:\/\/\).*\(:\)/\1$public_ipv4_address\2/g" $docker_compose
-  validator_endpoint_port=`grep endpoint $docker_compose | cut -d: -f3 | awk '{print $1}'`
+  last_public_ipv4_address=`grep "Public IP" $CREDITCOIN_HOME/check_node_sanity.log | tail -1 | awk '{print $NF}'`
+  [ -n "$last_public_ipv4_address" ]  &&  [ $last_public_ipv4_address != $public_ipv4_address ]  &&  {
+    # write warning to stderr
+    >&2 echo "Warning: Public IP address has recently changed.  Creditcoin nodes cannot have dynamic IP addresses."
+  }
+
+  # replace advertised Validator endpoint with current public IP address; retain existing port number
+  sed -i "s~\(endpoint tcp://\).*\(:\)~\1$public_ipv4_address\2~g" $docker_compose
+
+  if grep -q "peering dynamic" $docker_compose
+  then
+    local seeds=([0]="" [1]="")
+    evaluate_candidates_for_dynamic_peering seeds  &&  sed -i '/seeds tcp:.*\\/d' $docker_compose    # remove existing seeds
+
+    # insert new seeds into .yaml file
+    preamble="                --seeds tcp://"
+    for seed in "${seeds[@]}"
+    do
+      [ -n "$seed" ]  &&  sed -i '/peering dynamic.*\\/ s~^~'"$preamble$seed"' \\\n~' $docker_compose
+    done
+  fi
 
   sudo docker-compose -f $docker_compose down 2>/dev/null
   if sudo docker-compose -f $docker_compose up -d
@@ -35,6 +83,7 @@ function restart_creditcoin_node {
     echo Started Creditcoin node
 
     # check if Validator endpoint is reachable from internet
+    local validator_endpoint_port=`grep endpoint $docker_compose | cut -d: -f3 | awk '{print $1}'`
     nc -4 -z -w 1  $public_ipv4_address  $validator_endpoint_port  ||  {
       echo -n "TCP port $validator_endpoint_port isn't open. "
       validator=`ps -ef | grep "[u]sr/bin/sawtooth-validator"`

--- a/Server/sha256_speed_test.sh
+++ b/Server/sha256_speed_test.sh
@@ -1,0 +1,1 @@
+scripts/sha256_speed_test.sh

--- a/Server/start_creditcoin.sh
+++ b/Server/start_creditcoin.sh
@@ -1,0 +1,1 @@
+scripts/start_creditcoin.sh


### PR DESCRIPTION
1. Creditcoin startup script
- logs public IP address daily, helping end users pinpoint any node connectivity problems caused by DHCP 
- assigns current public IP address to Validator option --endpoint
- selects three new seeds from different subnets upon Validator restart
  - Sets option --seeds during a Validator restart.  The motivation is to distribute network load away from 'creditcoin-gateway' and 'creditcoin-node' by selecting three open peer nodes from the ping log.
- runs SHA-256 speed test no more than once every 30 days
  - The target machine spec is measured against a baseline established on Azure VM running 8-core Xeon Platinum 8171M CPU @ 2.60GHz.  A target machine whose spec falls below the baseline shouldn't be used to run CC software and the user must upgrade the target hardware.

2. Creditcoin configuration script
- schedules crontab job to run node sanity script
- defines and validates gateway RPC URLs
- schedules log rotation

3. Node sanity script
- every 30 minutes:
  - logs Validator peers and probes the remote endpoint port of each peer
  - logs number of file descriptors opened in Validator processes to help monitor level of TCP network activity
- auto-resets Creditcoin node if appropriate
  - Detects when a node reaches a bad state.  If the number of open Validator peers is zero, the CC node would be reset immediately.  If the number of open peers is one, the script examines the block tip and re-examines the tip in the next run.  If the tip hasn't changed and the number of open peers is still one, the CC node is auto-reset.