### PR TITLE
CRB-182 Test for containers read-only filesystem

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,31 @@ jobs:
         docker-compose -f Client/docker-compose.yaml up -d
         sleep 45
 
+        echo "**** CONTAINERS *****"
+        docker ps -a
+
+    - name: Search for dead containers
+      run: |
+        docker ps -a --filter "status=dead" --format "{{.Names}}, {{.ID}}, {{.Status}}"
+        HOW_MANY=$(docker ps -a --filter "status=dead" --format "{{.Names}}, {{.ID}}, {{.Status}}" | wc -l)
+        if [ "$HOW_MANY" -gt "0" ]; then
+            exit 1
+        fi
+
+    - name: Search for exited containers
+      run: |
+        docker ps -a --filter "status=exited" --format "{{.Names}}, {{.ID}}, {{.Status}}"
+        HOW_MANY=$(docker ps -a --filter "status=exited" --format "{{.Names}}, {{.ID}}, {{.Status}}" | wc -l)
+        if [ "$HOW_MANY" -gt "0" ]; then
+            exit 1
+        fi
+
+    - name: Sanity check if containers are working
+      run: |
+        # should print a list of all commands
+        docker exec -it creditcoin-client ./ccclient
+
+
     - name: Verify read-only filesystem
       run: |
         ERRORS=0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: docker
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+
+jobs:
+  read-only:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Start containers
+      run: |
+        # download first
+        docker-compose -f Server/docker-compose.yaml pull
+        docker-compose -f Client/docker-compose.yaml pull
+
+        # start containers
+        # Note: keys are missing in .json config files and the containers
+        # will not function properly but that should be good enough to evaluate
+        # if the root filesystem is read-only
+        docker-compose -f Server/docker-compose.yaml up -d
+        docker-compose -f Client/docker-compose.yaml up -d
+        sleep 45
+
+    - name: Verify read-only filesystem
+      run: |
+        ERRORS=0
+
+        for CONTAINER_NAME in `docker ps --format "{{.Names}}"`; do
+            echo "INFO: ----- checking $CONTAINER_NAME -----"
+            DIFF=`docker diff $CONTAINER_NAME`
+            echo "$DIFF"
+
+            if [ -n "$DIFF" ]; then
+                echo "FAILED: unexpected changes to filesystem found for $CONTAINER_NAME"
+                ERRORS=$((ERRORS+1))
+            fi
+        done
+
+        exit $ERRORS

--- a/Client/docker-compose.yaml
+++ b/Client/docker-compose.yaml
@@ -22,6 +22,9 @@ services:
     network_mode: "host"
     image: gluwa/creditcoin-client:1.7
     container_name: creditcoin-client
+    read_only: true
+    tmpfs:
+      - /home/Creditcoin/Client/plugins
     tty: true
     stdin_open: true
     secrets:

--- a/Server/docker-compose.yaml
+++ b/Server/docker-compose.yaml
@@ -22,6 +22,9 @@ services:
   settings-tp:
     image: hyperledger/sawtooth-settings-tp:1.0
     container_name: sawtooth-settings-tp-default
+    read_only: true
+    tmpfs:
+      - /var/log/sawtooth
     depends_on:
       - validator
     entrypoint: settings-tp -C tcp://validator:4004
@@ -35,6 +38,9 @@ services:
   validator:
     image: gluwa/creditcoin-validator:1.7
     container_name: sawtooth-validator-default
+    read_only: true
+    tmpfs:
+      - /var/log/sawtooth
     volumes:
       - type: volume
         source: validator-block-volume
@@ -78,6 +84,9 @@ services:
   rest-api:
     image: gluwa/sawtooth-rest-api:1.7
     container_name: sawtooth-rest-api-default
+    read_only: true
+    tmpfs:
+      - /var/log/sawtooth
     ports:
       - 8008:8008
     secrets:
@@ -96,6 +105,7 @@ services:
   processor:
     image: gluwa/creditcoin-processor:1.7
     container_name: creditcoin-processor
+    read_only: true
     depends_on:
       - validator
       - settings-tp
@@ -110,6 +120,7 @@ services:
   gateway:
     image: gluwa/creditcoin-gateway:1.7
     container_name: creditcoin-gateway
+    read_only: true
     expose:
       - 55555
     ports:


### PR DESCRIPTION
we don't want containers to modify any files inside of the image once they are up and running.

This should also be supplemented with individual checks for each container. They could be added after the proposed health check changes.